### PR TITLE
fix: handle token counting fallback in history trim

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -238,8 +238,17 @@ def trim_history_by_tokens(tok: AutoTokenizer, messages: List[Dict[str,str]], ma
     other   = [m for m in messages if m.get("role") != "system"]
 
     def count_tokens(msgs: List[Dict[str,str]]) -> int:
-        t = tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=False)
-        return len(tok(t).input_ids)
+        try:
+            text = tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=False)
+        except Exception:
+            buf = []
+            for m in msgs:
+                role = m.get("role", "user")
+                content = m.get("content", "")
+                buf.append(f"<|{role}|> {content}")
+            text = "\n".join(buf)
+        encoding = tok(text)
+        return len(encoding["input_ids"])
 
     kept: List[Dict[str,str]] = []
     kept.extend(sys_msgs)


### PR DESCRIPTION
## Summary
- add a manual fallback in `trim_history_by_tokens` when `apply_chat_template` is unavailable
- ensure the tokenizer encodes the fallback prompt text so the history window respects the token budget

## Testing
- python - <<'PY'
from agent import trim_history_by_tokens

class DummyTokenizer:
    def apply_chat_template(self, *args, **kwargs):
        raise ValueError("no template available")

    def __call__(self, text):
        tokens = text.split()
        return {"input_ids": list(range(len(tokens)))}

messages = [
    {"role": "system", "content": "sys"},
    {"role": "user", "content": "hello"},
    {"role": "assistant", "content": "hi"},
    {"role": "user", "content": "tell me more"},
]

trimmed = trim_history_by_tokens(DummyTokenizer(), messages, max_tokens=6)
print(trimmed)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e0f5459d088321b54a232b64d74d84