### PR TITLE
Fix streaming fallback handling for empty responses

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -318,6 +318,8 @@ class LocalAgent:
             eos_token_id=self.tok.eos_token_id,
         )
 
+        fallback_kwargs = generation_kwargs
+
         if self.stream_output:
             streamer = TextIteratorStreamer(
                 self.tok,
@@ -340,10 +342,12 @@ class LocalAgent:
 
             thread.join()
             text = "".join(collected).strip()
+
+            fallback_kwargs = {k: v for k, v in generation_kwargs.items() if k != "streamer"}
             if text:
                 return text
 
-        out = self.model.generate(**generation_kwargs)
+        out = self.model.generate(**fallback_kwargs)
         return self.tok.decode(out[0], skip_special_tokens=True)
 
     @staticmethod

--- a/tests/test_local_agent.py
+++ b/tests/test_local_agent.py
@@ -1,0 +1,56 @@
+import pathlib
+import sys
+import threading
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from agent import LocalAgent
+
+
+class DummyTokenizer:
+    eos_token_id = 0
+
+    def decode(self, tokens, skip_special_tokens=True):  # pragma: no cover - trivial
+        return "decoded"
+
+
+class DummyModel:
+    def __init__(self):
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def generate(self, **kwargs):
+        with self._lock:
+            self.calls.append(kwargs)
+        if "streamer" in kwargs:
+            return None
+        return [[1, 2, 3]]
+
+
+class DummyStreamer:
+    def __init__(self, *_, **__):
+        self._chunks = []
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+
+def test_streaming_immediate_eos(monkeypatch):
+    agent = object.__new__(LocalAgent)
+    agent.stream_output = True
+    agent.tok = DummyTokenizer()
+    dummy_model = DummyModel()
+    agent.model = dummy_model
+
+    monkeypatch.setattr("transformers.TextIteratorStreamer", DummyStreamer)
+
+    model_inputs = {"input_ids": [[0]], "attention_mask": [[1]]}
+
+    result = LocalAgent._generate_text(agent, model_inputs)
+
+    assert result == "decoded"
+    assert len(dummy_model.calls) == 2
+    assert "streamer" in dummy_model.calls[0]
+    assert "streamer" not in dummy_model.calls[1]


### PR DESCRIPTION
## Summary
- adjust LocalAgent streaming path to strip the streamer from fallback kwargs and reuse collected output safely
- add a regression test that mocks an immediate end-of-sequence generation to ensure a tensor fallback without TypeError

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0ff6c8974832183f21f0da170b402