### PR TITLE
Add dependency manifest and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Agent Lab
+
+## Instalacja zależności
+Aby zainstalować wymagane biblioteki uruchom:
+
+```bash
+pip install -r requirements.txt
+```
+
+Plik `requirements.txt` zawiera listę bezpośrednich zależności projektu, w tym `transformers`, `torch`, `numpy`, `requests` oraz `pytest`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+transformers>=4.44
+torch
+numpy
+requests
+pytest


### PR DESCRIPTION
## Summary
- add a requirements.txt with the direct Python dependencies
- document how to install dependencies from the new requirements file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1080a01c083219ce5702332716497